### PR TITLE
fix ip leak and restart section for case minutes

### DIFF
--- a/files/tor-router
+++ b/files/tor-router
@@ -5,8 +5,8 @@ RULES="/var/tmp/tor-router.save"
 # Tor's TransPort
 TRANS_PORT="9040"
 
-case "$1" in
-start)
+function startTR()
+{
 	if test -f "$RULES"; then
 		echo "$RULES exists. Either delete it, or stop tor-router first."
 		exit 1
@@ -54,12 +54,14 @@ start)
 			done
 
 			iptables -A OUTPUT -m owner --uid-owner "$TOR_UID" -j ACCEPT
-			iptables -A OUTPUT -j ACCEPT
+			iptables -A OUTPUT -j REJECT # ACCEPTから変更
 		fi
 	fi
-	;;
-stop)
-	if test -f "$RULES"; then
+}
+
+function stopTR()
+{
+		if test -f "$RULES"; then
 		echo "Restoring previous rules from $RULES"
 		iptables -t nat -F
 		iptables-restore <"$RULES"
@@ -68,11 +70,23 @@ stop)
 		echo "$RULES does not exist. Not doing anything."
 		exit
 	fi
+}
+
+function restartTR()
+{
+	stopTR
+	startTR
+}
+
+case "$1" in
+start)
+	startTR
+	;;
+stop)
+	stopTR
 	;;
 restart)
-	stop
-	sleep 2
-	start
+	restartTR
 	;;
 *)
 	echo "Usage: $0 {start|stop|restart}"


### PR DESCRIPTION
# Overview
## Fix iptables flaws
The iptables on line 56 allows traffic for processes belonging to Tor's UID, but when the subsequent rule on line 57 is reached, it allows all traffic that does not meet the above criteria, causing an IP leak to an unspecified web site. This problem can be seen in ipinfo.io.

Specifically, the code is as follows

```bash
iptables -A OUTPUT -m owner --uid-owner "$TOR_UID" -j ACCEPT
iptables -A OUTPUT -j ACCEPT
```
## Fix restart command
There was a bug in the restart command that prevented it from triggering `stop` and `start` correctly. To solve this problem, we have made the content of case independent as a function.

````bash
function startTR()
{
	if test -f "$RULES"; then
		echo "$RULES exists. Either delete it, or stop tor-router first.
		exit 1
	else
		iptables-save >$RULES
# ... Skip...



case "$1" in
start)
	startTR
	;;
stop)
	stopTR
	;;
restart)
	restartTR
	;;
*)

```